### PR TITLE
feat: Add .env.example for frontend

### DIFF
--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,0 +1,8 @@
+# Example environment variables for the frontend application
+
+# Base URL for the backend API
+VITE_API_BASE_URL=/api
+
+# Other frontend-specific environment variables can be added here
+# For example:
+# VITE_FEATURE_FLAG_NEW_DESIGN=true


### PR DESCRIPTION
Adds a `.env.example` file to the `webapp/` directory. This file includes `VITE_API_BASE_URL` as an example environment variable, guiding developers on setting up their local `.env` file for frontend configuration.