### PR TITLE
fix: Resolve backend TypeScript compilation errors

### DIFF
--- a/server/src/collaborations/collaborations.controller.ts
+++ b/server/src/collaborations/collaborations.controller.ts
@@ -10,13 +10,20 @@ import {
   UsePipes,
   ParseUUIDPipe,
   Logger,
-  ForbiddenException, // For checking user ID against collaboration record
+  // ForbiddenException, // Not directly used in this controller, service handles it
+  // NotFoundException, // Not directly used in this controller, service handles it
+  Delete, // Added
+  HttpCode, // Added
+  HttpStatus, // Added
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-import { MemoirsService } from '../memoirs/memoirs.service'; // Assuming logic remains in MemoirsService for now
+import { MemoirsService } from '../memoirs/memoirs.service';
 import { MemoirCollaboration } from '../memoirs/entities/memoir-collaboration.entity';
 import { RespondToInvitationDto } from '../memoirs/dto/respond-to-invitation.dto';
-import { CollaborationStatus } from '../memoirs/enums/collaboration-status.enum';
+// import { CollaborationStatus } from '../memoirs/enums/collaboration-status.enum'; // Not directly used, DTO uses it
+import { UpdateCollaborationRoleDto } from '../memoirs/dto/update-collaboration-role.dto.ts'; // Added import
+// import { CollaborationRole } from '../memoirs/enums/collaboration-role.enum'; // Not directly used, DTO uses it
+
 
 interface AuthenticatedRequest extends Request {
   user: {

--- a/server/src/memoirs/entities/like.entity.ts
+++ b/server/src/memoirs/entities/like.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   JoinColumn,
   Unique,
+  Column, // Added Column import
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 import { Memoir } from './memoir.entity';

--- a/server/src/service-requests/entities/service-request.entity.ts
+++ b/server/src/service-requests/entities/service-request.entity.ts
@@ -55,7 +55,7 @@ export class ServiceRequest {
   @Column({
     type: 'enum',
     enum: ServiceRequestStatus,
-    default: ServiceRequestStatus.PENDING, // Assuming PENDING is the default from your enum
+    default: ServiceRequestStatus.PENDING_REVIEW,
   })
   status: ServiceRequestStatus;
 

--- a/server/src/service-requests/service-requests.service.ts
+++ b/server/src/service-requests/service-requests.service.ts
@@ -33,7 +33,7 @@ export class ServiceRequestsService {
       contactPhone: createDto.contactPhone,
       address: createDto.address,
       preferredDate: createDto.preferredDate ? new Date(createDto.preferredDate) : null,
-      status: ServiceRequestStatus.PENDING, // Default status (ensure PENDING_REVIEW is PENDING in enum)
+      status: ServiceRequestStatus.PENDING_REVIEW,
     });
 
     return this.serviceRequestRepository.save(newServiceRequest);


### PR DESCRIPTION
This commit fixes several TypeScript compilation errors in the backend (`server/`) that were identified after recent feature additions and modifications.

Key fixes include:

- **`CollaborationsController`**:
    - Corrected the import path for `UpdateCollaborationRoleDto`.
    - Added missing NestJS common module imports (`Delete`, `HttpCode`, `HttpStatus`).
- **`Like` Entity (`memoirs/entities/like.entity.ts`)**:
    - Ensured all necessary TypeORM decorators (including `Column`) are correctly imported.
- **`ServiceRequestStatus` Enum Usage**:
    - Standardized the use of `ServiceRequestStatus.PENDING_REVIEW` (instead of a non-existent `PENDING`) in `service-requests/entities/service-request.entity.ts` (for default status) and in `service-requests/service-requests.service.ts` (for initial status in the `create` method), aligning with the enum definition.

These changes should resolve the reported build failures and allow the backend to compile successfully.